### PR TITLE
add links to documentation into a new help popup

### DIFF
--- a/src/screens/App/Customers/index.js
+++ b/src/screens/App/Customers/index.js
@@ -11,6 +11,7 @@ import {
 	Button,
 	primaryBlack,
 	P,
+	A,
 } from '../../../utils/new/design-system';
 import CustomerModalAndMail from '../../../components/CustomerModalAndMail';
 import ConfirmModal from '../../../components/ConfirmModal';
@@ -113,15 +114,38 @@ const Row = styled('tr')`
 	}
 `;
 
-const Forms = styled('div')`
+const Actions = styled('div')`
 	display: flex;
-	flex-direction: row-reverse;
+	flex-direction: row;
+	align-items: center;
+	justify-content: flex-end;
+
+	* ~ * {
+		margin-left: 2rem;
+	}
+
+	@media (max-width: ${BREAKPOINTS}px) {
+		flex-direction: column-reverse;
+		justify-content: flex-start;
+
+		* ~ * {
+			margin-left: 0;
+			margin-bottom: 0.5rem;
+		}
+	}
+`;
+
+const Forms = styled('div')`
+	display: grid;
+	grid-template-columns: 50% 1fr;
 	align-items: center;
 	justify-content: space-between;
 
 	@media (max-width: ${BREAKPOINTS}px) {
+		display: flex;
 		flex-direction: column;
-		margin-bottom: 1rem;
+		align-items: stretch;
+		margin-bottom: 2rem;
 	}
 `;
 
@@ -174,9 +198,6 @@ const Customers = () => {
 			<Container>
 				<Heading>Clients</Heading>
 				<Forms>
-					<Button big onClick={() => setEditCustomer(true)}>
-						Créer un nouveau client
-					</Button>
 					<FilterInput
 						icon={Search}
 						name="filter"
@@ -185,6 +206,14 @@ const Customers = () => {
 						onChange={e => setFilter(e.target.value)}
 						value={filter}
 					/>
+					<Actions>
+						<A target="_blank" href="https://inyo.pro">
+							Présenter Inyo à un client
+						</A>
+						<Button big onClick={() => setEditCustomer(true)}>
+							Créer un nouveau client
+						</Button>
+					</Actions>
 				</Forms>
 				<Table>
 					<thead>

--- a/src/screens/App/Dashboard/index.js
+++ b/src/screens/App/Dashboard/index.js
@@ -6,7 +6,9 @@ import Tasks from './tasks';
 import CreateTask from '../../../components/CreateTask';
 import SidebarDashboardInfos from '../../../components/SidebarDashboardInfos';
 
-import {Main, Container, Content} from '../../../utils/new/design-system';
+import {
+	Main, Container, Content, Help,
+} from '../../../utils/new/design-system';
 
 function Dashboard({history}) {
 	const setProjectSelected = (selected, removeCustomer) => {
@@ -30,6 +32,13 @@ function Dashboard({history}) {
 
 	return (
 		<Container>
+			<Help
+				customerToken
+				data-tip="Instructions pour utiliser l'interface"
+				onClick={() => history.push('/app/tasks?openHelpModal=true')}
+			>
+				?
+			</Help>
 			<Main>
 				<Content>
 					<CreateTask setProjectSelected={setProjectSelected} />

--- a/src/screens/App/Projects/index.js
+++ b/src/screens/App/Projects/index.js
@@ -42,6 +42,7 @@ import {
 	IllusContainer,
 	IllusText,
 	IllusTextIcon,
+	Help,
 } from '../../../utils/new/design-system';
 
 const ProjectTitle = styled(SubHeading)`
@@ -190,6 +191,13 @@ function Projects({history}) {
 
 	return (
 		<Container>
+			<Help
+				customerToken
+				data-tip="Instructions pour utiliser l'interface"
+				onClick={() => history.push('/app/tasks?openHelpModal=true')}
+			>
+				?
+			</Help>
 			<ReactTooltip effect="solid" delayShow={TOOLTIP_DELAY} />
 			<Main>
 				<Content

--- a/src/screens/App/Tasks/tasks-lists.js
+++ b/src/screens/App/Tasks/tasks-lists.js
@@ -16,7 +16,9 @@ import {
 	Help,
 	Heading,
 	Button,
+	A,
 	P,
+	UL,
 	Main,
 	Container,
 	Content,
@@ -121,6 +123,7 @@ function TasksList({location, history}) {
 	const query = new URLSearchParams(prevSearch || location.search);
 	const linkedCustomerId = query.get('customerId');
 	const openModal = query.get('openModal');
+	const openHelpModal = query.get('openHelpModal');
 	const projectId = query.get('projectId');
 	const filter = query.get('filter');
 	const view = query.get('view');
@@ -186,7 +189,7 @@ function TasksList({location, history}) {
 			<Help
 				customerToken
 				data-tip="Instructions pour utiliser l'interface"
-				onClick={() => history.push('?openModal=true')}
+				onClick={() => history.push('?openHelpModal=true')}
 			>
 				?
 			</Help>
@@ -243,6 +246,105 @@ function TasksList({location, history}) {
 						<YoutubeContainer>
 							<IframeYouTube videoId="qBJvclaZ-yQ" />
 						</YoutubeContainer>
+						<ModalActions>
+							<Button
+								big
+								primary
+								onClick={() => history.push('/app/tasks')}
+							>
+								J'ai compris!
+							</Button>
+						</ModalActions>
+					</ModalElem>
+				</ModalContainer>
+			)}
+			{openHelpModal && (
+				<ModalContainer
+					size="small"
+					onDismiss={() => history.push('/app/tasks')}
+				>
+					<ModalElem>
+						<Heading>Aide</Heading>
+						<PA>
+							Voici quelques liens pour vous aider à utiliser
+							Inyo.
+						</PA>
+						<PA>
+							<UL noBullet>
+								<li>
+									🎬 -{' '}
+									<A
+										href=""
+										onClick={() => history.push('?openModal=true')
+										}
+									>
+										Voir la vidéo de présentation
+									</A>
+								</li>
+								<li>
+									✅ -{' '}
+									<A
+										target="_blank"
+										href="https://site.inyo.me/documentation/creer-une-nouvelle-tache/"
+									>
+										Créer une nouvelle tâche
+									</A>
+								</li>
+								<li>
+									🤑 -{' '}
+									<A
+										target="_blank"
+										href="https://site.inyo.me/documentation/liste-de-mes-clients/"
+									>
+										Créer un nouveau client
+									</A>
+								</li>
+								<li>
+									🗂️ -{' '}
+									<A
+										target="_blank"
+										href="https://site.inyo.me/documentation/creer-un-nouveau-projet/"
+									>
+										Créer un nouveau projet
+									</A>
+								</li>
+								<li>
+									📝 -{' '}
+									<A
+										target="_blank"
+										href="https://site.inyo.me/documentation/creer-un-nouveau-projet/utiliser-un-modele-predefini/"
+									>
+										Utiliser un modèle de projet
+									</A>
+								</li>
+								<li>
+									🕵️ -{' '}
+									<A
+										target="_blank"
+										href="https://site.inyo.me/documentation/les-principales-vues/vue-du-client-d-un-projet/"
+									>
+										Voir ce que voit le client
+									</A>
+								</li>
+								<li>
+									🌀 -{' '}
+									<A target="_blank" href="https://inyo.pro">
+										Présenter Inyo à votre client
+									</A>
+								</li>
+							</UL>
+						</PA>
+						<PA>
+							Une information est manquante? Contactez-nous via la
+							messagerie en bas à droite, ou proposez des
+							fonctionnalités sur{' '}
+							<A
+								target="_blank"
+								href="https://site.inyo.me/produit/fonctionnalites/proposer-une-fonctionnalite/"
+							>
+								notre roadmap collaborative.
+							</A>
+						</PA>
 						<ModalActions>
 							<Button
 								big

--- a/src/screens/App/Tasks/tasks-lists.js
+++ b/src/screens/App/Tasks/tasks-lists.js
@@ -285,7 +285,7 @@ function TasksList({location, history}) {
 									✅ -{' '}
 									<A
 										target="_blank"
-										href="https://site.inyo.me/documentation/creer-une-nouvelle-tache/"
+										href="https://inyo.me/documentation/creer-une-nouvelle-tache/"
 									>
 										Créer une nouvelle tâche
 									</A>
@@ -294,7 +294,7 @@ function TasksList({location, history}) {
 									🤑 -{' '}
 									<A
 										target="_blank"
-										href="https://site.inyo.me/documentation/liste-de-mes-clients/"
+										href="https://inyo.me/documentation/liste-de-mes-clients/"
 									>
 										Créer un nouveau client
 									</A>
@@ -303,7 +303,7 @@ function TasksList({location, history}) {
 									🗂️ -{' '}
 									<A
 										target="_blank"
-										href="https://site.inyo.me/documentation/creer-un-nouveau-projet/"
+										href="https://inyo.me/documentation/creer-un-nouveau-projet/"
 									>
 										Créer un nouveau projet
 									</A>
@@ -312,7 +312,7 @@ function TasksList({location, history}) {
 									📝 -{' '}
 									<A
 										target="_blank"
-										href="https://site.inyo.me/documentation/creer-un-nouveau-projet/utiliser-un-modele-predefini/"
+										href="https://inyo.me/documentation/creer-un-nouveau-projet/utiliser-un-modele-predefini/"
 									>
 										Utiliser un modèle de projet
 									</A>
@@ -321,7 +321,7 @@ function TasksList({location, history}) {
 									🕵️ -{' '}
 									<A
 										target="_blank"
-										href="https://site.inyo.me/documentation/les-principales-vues/vue-du-client-d-un-projet/"
+										href="https://inyo.me/documentation/les-principales-vues/vue-du-client-d-un-projet/"
 									>
 										Voir ce que voit le client
 									</A>
@@ -340,7 +340,7 @@ function TasksList({location, history}) {
 							fonctionnalités sur{' '}
 							<A
 								target="_blank"
-								href="https://site.inyo.me/produit/fonctionnalites/proposer-une-fonctionnalite/"
+								href="https://inyo.me/produit/fonctionnalites/proposer-une-fonctionnalite/"
 							>
 								notre roadmap collaborative.
 							</A>

--- a/src/utils/new/design-system.js
+++ b/src/utils/new/design-system.js
@@ -563,6 +563,11 @@ export const Content = styled('div')`
 	${props => (props.small ? 'margin: 0 auto' : '')};
 `;
 
+export const UL = styled('ul')`
+	${props => (props.noBullet ? 'padding: 0' : '')};
+	${props => (props.noBullet ? 'list-style-type: none' : '')};
+`;
+
 export const IllusContainer = styled('div')`
 	height: 660px;
 	background: url('${props => props.bg}');


### PR DESCRIPTION
Currently the popup leads to /app/tasks
thats means that if you are currently on the dashboard, you will be redirected to all tasks : (