### PR TITLE
fix suspense showing when adding a task. Request was fire because of a

### DIFF
--- a/src/utils/fragments.js
+++ b/src/utils/fragments.js
@@ -27,6 +27,7 @@ export const SHORT_TASK_FRAGMENT = gql`
 		isFocused
 		scheduledFor
 		schedulePosition
+		dailyRate
 		owner {
 			id
 		}


### PR DESCRIPTION
missing field and ShortTaskFragment (dailyRate)